### PR TITLE
Adding unit tests for ElementToTypeAndFilePairFunction

### DIFF
--- a/mezzanine-compiler/src/main/java/com/anthonycr/mezzanine/function/ElementToTypeAndFilePairFunction.kt
+++ b/mezzanine-compiler/src/main/java/com/anthonycr/mezzanine/function/ElementToTypeAndFilePairFunction.kt
@@ -24,8 +24,6 @@ object ElementToTypeAndFilePairFunction : Function<Element, Pair<TypeElement, Fi
 
         val filePath = element.getAnnotation(FileStream::class.java).value
 
-        requireNotNull(filePath)
-
         val currentRelativePath = Paths.get("")
 
         val absoluteFilePath = "${currentRelativePath.toAbsolutePath()}${prependSlashIfNecessary(filePath)}"

--- a/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/MezzanineProcessorTest.kt
+++ b/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/MezzanineProcessorTest.kt
@@ -2,6 +2,7 @@ package com.anthonycr.mezzanine
 
 import org.junit.Test
 import testcase.InvalidFileTestCase
+import testcase.ValidFileExtraSlashTestCase
 import testcase.ValidFileTestCase
 import javax.tools.Diagnostic
 
@@ -20,9 +21,17 @@ class MezzanineProcessorTest : AbstractAnnotationProcessorTest() {
     }
 
     @Test
+    fun testValidFileExtraSlashCase_Succeeds() {
+        val output = compileTestCase(ValidFileExtraSlashTestCase::class.java)
+
+        assertCompilationSuccessful(output)
+    }
+
+    @Test
     fun test_InvalidFileCase_Fails() {
         val output = compileTestCase(InvalidFileTestCase::class.java)
 
         assertCompilationReturned(arrayOf(Diagnostic.Kind.ERROR), longArrayOf(9), output)
     }
+
 }

--- a/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/function/ElementToTypeAndFilePairFunctionTest.kt
+++ b/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/function/ElementToTypeAndFilePairFunctionTest.kt
@@ -1,0 +1,19 @@
+package com.anthonycr.mezzanine.function
+
+import org.junit.Test
+import org.mockito.Mockito
+import javax.lang.model.element.ExecutableElement
+
+/**
+ * Additional unit tests for [ElementToTypeAndFilePairFunction].
+ */
+class ElementToTypeAndFilePairFunctionTest {
+
+    @Test(expected = Exception::class)
+    fun test_NonTypeElement_ThrowsException() {
+        val executableElement = Mockito.mock(ExecutableElement::class.java)
+
+        ElementToTypeAndFilePairFunction.apply(executableElement)
+    }
+
+}

--- a/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/function/GenerateFileStreamTypeSpecFunctionTest.kt
+++ b/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/function/GenerateFileStreamTypeSpecFunctionTest.kt
@@ -1,0 +1,30 @@
+package com.anthonycr.mezzanine.function
+
+import org.junit.Test
+import org.mockito.Mockito
+import javax.lang.model.element.TypeElement
+import javax.lang.model.element.VariableElement
+
+/**
+ * Additional unit tests for [GenerateFileStreamTypeSpecFunction].
+ */
+class GenerateFileStreamTypeSpecFunctionTest {
+
+    @Test(expected = IndexOutOfBoundsException::class)
+    fun test_TypeElementWithNoEnclosedElements_Fails() {
+        val typeElement = Mockito.mock(TypeElement::class.java)
+        Mockito.`when`(typeElement.enclosedElements).thenReturn(mutableListOf())
+
+        GenerateFileStreamTypeSpecFunction.apply(Pair(typeElement, ""))
+    }
+
+    @Test(expected = ClassCastException::class)
+    fun test_TypeElementWithNonMethodElement_Fails() {
+        val typeElement = Mockito.mock(TypeElement::class.java)
+        val field = Mockito.mock(VariableElement::class.java)
+        Mockito.`when`(typeElement.enclosedElements).thenReturn(mutableListOf(field))
+
+        GenerateFileStreamTypeSpecFunction.apply(Pair(typeElement, ""))
+    }
+
+}

--- a/mezzanine-compiler/src/test/java/testcase/ValidFileExtraSlashTestCase.java
+++ b/mezzanine-compiler/src/test/java/testcase/ValidFileExtraSlashTestCase.java
@@ -1,0 +1,13 @@
+package testcase;
+
+import com.anthonycr.mezzanine.FileStream;
+
+/**
+ * A test case for {@code Test.json}.
+ */
+@FileStream("/src/test/Test.json")
+public interface ValidFileExtraSlashTestCase {
+
+    String test();
+
+}


### PR DESCRIPTION
Adding unit tests for ElementToTypeAndFilePairFunction. Removed a `require` call on the value returned by the annotation since the compiler won't let a null be passed as a value in an annotation.