### PR TITLE
Adding unit tests for some error cases

### DIFF
--- a/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/extensions/FunctionExtensionsKtTest.kt
+++ b/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/extensions/FunctionExtensionsKtTest.kt
@@ -10,7 +10,7 @@ class FunctionExtensionsKtTest {
 
 
     @Test
-    fun test_DoOnNext() {
+    fun `doOnNext iterates through list and returns same list`() {
         val listOne = listOf("one", "two", "three")
 
         val listTwo = mutableListOf<String>()

--- a/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/function/GenerateFileStreamTypeSpecFunctionTest.kt
+++ b/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/function/GenerateFileStreamTypeSpecFunctionTest.kt
@@ -11,7 +11,7 @@ import javax.lang.model.element.VariableElement
 class GenerateFileStreamTypeSpecFunctionTest {
 
     @Test(expected = IndexOutOfBoundsException::class)
-    fun test_TypeElementWithNoEnclosedElements_Fails() {
+    fun `TypeElement with no enclosed elements fails`() {
         val typeElement = Mockito.mock(TypeElement::class.java)
         Mockito.`when`(typeElement.enclosedElements).thenReturn(mutableListOf())
 
@@ -19,7 +19,7 @@ class GenerateFileStreamTypeSpecFunctionTest {
     }
 
     @Test(expected = ClassCastException::class)
-    fun test_TypeElementWithNonMethodElement_Fails() {
+    fun `TypeElement with non ExecutableElement fails`() {
         val typeElement = Mockito.mock(TypeElement::class.java)
         val field = Mockito.mock(VariableElement::class.java)
         Mockito.`when`(typeElement.enclosedElements).thenReturn(mutableListOf(field))
@@ -27,4 +27,11 @@ class GenerateFileStreamTypeSpecFunctionTest {
         GenerateFileStreamTypeSpecFunction.invoke(Pair(typeElement, ""))
     }
 
+    @Test(expected = TypeCastException::class)
+    fun `TypeElement with null enclosed element fails`() {
+        val typeElement = Mockito.mock(TypeElement::class.java)
+        Mockito.`when`(typeElement.enclosedElements).thenReturn(mutableListOf(null))
+
+        GenerateFileStreamTypeSpecFunction.invoke(Pair(typeElement, ""))
+    }
 }

--- a/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/utils/MessagerUtilsTest.kt
+++ b/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/utils/MessagerUtilsTest.kt
@@ -1,0 +1,22 @@
+package com.anthonycr.mezzanine.utils
+
+import org.junit.Test
+import org.mockito.Mockito.mock
+import javax.lang.model.element.Element
+
+/**
+ * Unit tests for [MessagerUtils].
+ */
+class MessagerUtilsTest {
+
+    @Test(expected = UninitializedPropertyAccessException::class)
+    internal fun `reportError fails when uninitialized`() {
+        val element = mock(Element::class.java)
+        MessagerUtils.reportError(element, "test error")
+    }
+
+    @Test(expected = UninitializedPropertyAccessException::class)
+    internal fun `reportInfo fails when uninitialized`() {
+        MessagerUtils.reportInfo("test message")
+    }
+}


### PR DESCRIPTION
Unit tests for error cases.
- Test for null input case in GenerateFileStreamTypeSpecFunction
- Test for uninitialized lateinit in MessagerUtils