### PR TITLE
Log path for file not found errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
 android:
   components:
-    - build-tools-27.0.0
+    - build-tools-27.0.1
     - android-27
   licenses:
     - 'android-sdk-license-.+'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 1.0.2 *(2017-12-06)*
+----------------------------
+- Mezzanine now logs the resolved path of the file to aid in debugging if the file cannot be found.
+
 Version 1.0.1 *(2017-11-04)*
 ----------------------------
 - Mezzanine generated class is now `final` and has a `private` constructor.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ allprojects {
 
 ##### Android/Java
 ```groovy
-def mezzanineVersion = '1.0.1'
+def mezzanineVersion = '1.0.2'
 compile "com.anthonycr.mezzanine:mezzanine:$mezzanineVersion"
 annotationProcessor "com.anthonycr.mezzanine:mezzanine-compiler:$mezzanineVersion"
 ```
@@ -33,7 +33,7 @@ annotationProcessor "com.anthonycr.mezzanine:mezzanine-compiler:$mezzanineVersio
 ```groovy
 apply plugin: 'kotlin-kapt'
 
-def mezzanineVersion = '1.0.1'
+def mezzanineVersion = '1.0.2'
 compile "com.anthonycr.mezzanine:mezzanine:$mezzanineVersion"
 kapt "com.anthonycr.mezzanine:mezzanine-compiler:$mezzanineVersion"
 ```
@@ -45,7 +45,7 @@ plugins {
 }
 
 dependencies {
-    def mezzanineVersion = '1.0.1'
+    def mezzanineVersion = '1.0.2'
     compile "com.anthonycr.mezzanine:mezzanine:$mezzanineVersion"
     apt "com.anthonycr.mezzanine:mezzanine-compiler:$mezzanineVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,11 @@ task clean(type: Delete) {
 
 subprojects {
     group = 'com.anthonycr.mezzanine'
-    version = '1.0.1'
+    version = '1.0.2'
 }
 
 ext {
-    versionName = '1.0.1'
+    versionName = '1.0.2'
 
     publishGroupId = 'com.anthonycr.mezzanine'
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlinVersion = '1.1.51'
+    ext.kotlinVersion = '1.2.0'
     ext.dokkaVersion = '0.9.15'
     repositories {
         google()

--- a/mezzanine-compiler/build.gradle
+++ b/mezzanine-compiler/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:3.8.0'
-    testCompile 'org.mockito:mockito-core:2.10.0'
+    testCompile 'org.mockito:mockito-core:2.12.0'
     testCompile 'com.google.testing.compile:compile-testing:0.12'
 
 }

--- a/mezzanine-compiler/src/main/java/com/anthonycr/mezzanine/filter/NonExistentFileFilter.kt
+++ b/mezzanine-compiler/src/main/java/com/anthonycr/mezzanine/filter/NonExistentFileFilter.kt
@@ -10,9 +10,10 @@ import javax.lang.model.element.TypeElement
 object NonExistentFileFilter : (Pair<TypeElement, File>) -> Boolean {
 
     override fun invoke(pair: Pair<TypeElement, File>): Boolean {
-        return pair.second.exists().also {
+        val (element, file) = pair
+        return file.exists().also {
             if (!it) {
-                MessagerUtils.reportError(pair.first, "File does not exist")
+                MessagerUtils.reportError(element, "File does not exist at path: ${file.path}")
             }
         }
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.0'
+    buildToolsVersion '27.0.1'
     defaultConfig {
         applicationId "com.anthonycr.mezzanine.sample"
         minSdkVersion 16
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.0.0'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
 
     implementation project(':mezzanine')
     kapt project(':mezzanine-compiler')


### PR DESCRIPTION
# Issue
- https://github.com/anthonycr/Mezzanine/issues/22

# Summary
In order to improve debugging of errors, the compiler should log the resolved path when a file is not found. This PR adds that logging.