### PR TITLE
Fix warnings caused by logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
 android:
   components:
-    - build-tools-27.0.2
+    - build-tools-27.0.3
     - android-27
   licenses:
     - 'android-sdk-license-.+'

--- a/mezzanine-compiler/src/main/java/com/anthonycr/mezzanine/MezzanineProcessor.kt
+++ b/mezzanine-compiler/src/main/java/com/anthonycr/mezzanine/MezzanineProcessor.kt
@@ -42,7 +42,7 @@ class MezzanineProcessor : AbstractProcessor() {
 
         val projectRoot = processingEnv.options[OPTION_PROJECT_PATH] ?: Paths.get("").toAbsolutePath().toString()
 
-        MessagerUtils.reportInfo("Starting Mezzanine processing")
+        MessagerUtils.reportInfo("Starting processing")
 
         MezzanineElementSource(roundEnvironment)
                 .createElementStream()

--- a/mezzanine-compiler/src/main/java/com/anthonycr/mezzanine/utils/MessagerUtils.kt
+++ b/mezzanine-compiler/src/main/java/com/anthonycr/mezzanine/utils/MessagerUtils.kt
@@ -26,6 +26,6 @@ object MessagerUtils {
      *
      * @param message the message to log.
      */
-    fun reportInfo(message: String) = messager.printMessage(Kind.NOTE, "Mezzanine: $message")
+    fun reportInfo(message: String) = println("Mezzanine: $message")
 
 }

--- a/mezzanine-compiler/src/main/java/com/anthonycr/mezzanine/utils/MessagerUtils.kt
+++ b/mezzanine-compiler/src/main/java/com/anthonycr/mezzanine/utils/MessagerUtils.kt
@@ -26,6 +26,6 @@ object MessagerUtils {
      *
      * @param message the message to log.
      */
-    fun reportInfo(message: String) = messager.printMessage(Kind.NOTE, message)
+    fun reportInfo(message: String) = messager.printMessage(Kind.NOTE, "Mezzanine: $message")
 
 }

--- a/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/utils/MessagerUtilsTest.kt
+++ b/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/utils/MessagerUtilsTest.kt
@@ -15,8 +15,8 @@ class MessagerUtilsTest {
         MessagerUtils.reportError(element, "test error")
     }
 
-    @Test(expected = UninitializedPropertyAccessException::class)
-    internal fun `reportInfo fails when uninitialized`() {
+    @Test
+    internal fun `reportInfo does not fail when uninitialized`() {
         MessagerUtils.reportInfo("test message")
     }
 }


### PR DESCRIPTION
Using `Messager.printMessage(Kind.NOTE, ...)` causes warnings with later Kotlin versions. This PR switches to `System.out.println` instead. This causes logging to no-op and not display when compiling Kotlin, and causes logs to always display for Java projects. Because this processor does not log very much, I think this an acceptable compromise for https://github.com/anthonycr/Mezzanine/issues/30 until the `Messager` can be used again when the Kotlin compiler is fixed.