### PR TITLE
Deterministic compilation

### DIFF
--- a/mezzanine-compiler/build.gradle
+++ b/mezzanine-compiler/build.gradle
@@ -13,19 +13,21 @@ dependencies {
     kapt "com.google.auto.service:auto-service:$autoServiceVersion"
 
     // code generation
-    implementation 'com.squareup:javapoet:1.9.0'
+    implementation 'com.squareup:javapoet:1.11.1'
     implementation 'org.apache.commons:commons-text:1.1'
 
     // kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 
     implementation project(':mezzanine')
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.assertj:assertj-core:3.9.0'
-    testImplementation 'org.mockito:mockito-core:2.13.0'
-    testImplementation 'com.google.testing.compile:compile-testing:0.13'
+    testImplementation 'org.assertj:assertj-core:3.10.0'
+    testImplementation 'org.mockito:mockito-core:2.21.0'
+    testImplementation 'com.google.testing.compile:compile-testing:0.15'
 
+    // Used by both auto-service and compile-testing, we need to resolve the version for them.
+    implementation 'com.google.guava:guava:23.5-jre'
 }
 
 compileJava {

--- a/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/MezzanineProcessorTest.kt
+++ b/mezzanine-compiler/src/test/java/com/anthonycr/mezzanine/MezzanineProcessorTest.kt
@@ -15,7 +15,7 @@ import java.nio.file.Paths
  */
 class MezzanineProcessorTest {
 
-    private val processorTester = ProcessorTester({ MezzanineProcessor() })
+    private val processorTester = ProcessorTester { MezzanineProcessor() }
 
     @Test
     fun `ValidFileTestCase compilation succeeds`() {
@@ -40,6 +40,26 @@ class MezzanineProcessorTest {
     fun `InvalidFileTestCase compilation fails`() {
         assertThat(processorTester.compile(InvalidFileTestCase::class)).isUnsuccessful()
     }
+
+    @Test
+    fun `verify deterministic compilation`() {
+        val input = arrayOf(
+                ValidFileTestCase::class,
+                ValidFileExtraSlashTestCase::class
+        )
+
+        val compilationHash1 = processorTester.compile(*input).hashOutput()
+        val compilationHash2 = processorTester.compile(*input).hashOutput()
+
+        assertThat(compilationHash1).isEqualTo(compilationHash2)
+    }
+
+    /**
+     * Return the hashed contents of each file output by the [Compilation] joined to a single
+     * [String].
+     */
+    private fun Compilation.hashOutput() = generatedFiles()
+            .joinToString { it.getCharContent(false).hashCode().toString() }
 
     /**
      * An extension that asserts that a compilation is unsuccessful.


### PR DESCRIPTION
# Summary
Verify that compilation is deterministic between multiple compilations for the same input by verifying with a unit test.

## Dependencies updated
- Kotlin
- JavaPoet 
- AssertJ
- Mockito
- Compile-Testing
- Added Guava to fix binary compatibility problems between compile-testing and auto-service