### PR TITLE
Fix windows build incompatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.json text eol=lf

--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ val testJson = mezzanine<TestJson>() // Alternatively, call the generated constr
 val fileContents = testJson.produce()
 ```
 
+## Building Cross-Platform
+
+By default, Git checks out files in a repo using the platform default EOL character. This can result
+in Mezzanine seeing different file contents when building on Unix based systems or Windows systems.
+While this might not affect the functionality of the project, if you have assertions based around 
+the output or require that the files being read have a specific formatting, it is recommended that
+you set the EOL character explicitly in `.gitattributes` for the files you have Mezzanine read. For 
+example, in this project, the files we are reading are all JSON files, so the contents of our
+`.gitattributes` are as follows (so that we can support building on both Unix and Windows based 
+systems).
+
+```
+*.json text eol=lf
+```
+
 ## Additional Considerations
 - Files are assumed to be encoded as `UTF-8`.
 - Files must be less than `65kB`, otherwise compilation will fail.

--- a/mezzanine-plugin/plugin/src/main/java/com/anthonycr/mezzanine/plugin/task/GenerateMezzanineTask.kt
+++ b/mezzanine-plugin/plugin/src/main/java/com/anthonycr/mezzanine/plugin/task/GenerateMezzanineTask.kt
@@ -35,7 +35,7 @@ abstract class GenerateMezzanineTask : DefaultTask() {
     fun run() {
         val projectPath = relativePath.get()
         inputFiles.forEach { file ->
-            val fileRelativePath = file.path.substring(projectPath.length + 1)
+            val fileRelativePath = file.invariantSeparatorsPath.substring(projectPath.length + 1)
             val className = "_MezzanineReader_${fileRelativePath.hashCode().absoluteValue}"
             val text = file.readText()
             val escapedText = StringEscapeUtils.escapeJava(text).replace("$", "\\$")


### PR DESCRIPTION
Fixes incompatibility with windows and adds warning to README about potential variance in the output when there is no EOL explicitly set.